### PR TITLE
Fix for removal of zeroth index tab

### DIFF
--- a/partial-main.html
+++ b/partial-main.html
@@ -13,7 +13,7 @@
         <div ui-view = 'asr' ng-if="workspace.type == 'ASR'"></div>
       </div>
     </tab>
-    <tab select="addWorkspace()">
+    <tab ng-click="addWorkspace()">
       <tab-heading>
         <i class="fa fa-plus"></i>
       </tab-heading>


### PR DESCRIPTION
By using ng-click instead of select on the addworkspace tab, the function won't be called by the removal of the last real tab
